### PR TITLE
Fix sys exit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - 2.7
+install:
+  - touch hpOneView/test/__init__.py hpOneView/test/unit/__init__.py
+  - pip install tox
+script:
+  - tox -- --exit-zero --statistics --count

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/HewlettPackard/python-hpOneView.svg?branch=master)](https://travis-ci.org/HewlettPackard/python-hpOneView)
+
 hpOneView
 =========
 

--- a/hpOneView/servers.py
+++ b/hpOneView/servers.py
@@ -339,6 +339,10 @@ class servers(object):
                                        serialNumberType, serverHardwareTypeUri,
                                        serverHardwareUri,
                                        serverProfileTemplateUri, uuid, wwnType)
+
+        # missing required field: enclousure group
+        # E.g.: profile['enclosureGroupUri'] =  "/rest/enclosure-groups/a0f1c07b-f811-4c85-8e38-ac5ec34ea2f4"
+
         task, body = self._con.post(uri['profiles'], profile)
         if profile['firmware'] is None:
             tout = 600

--- a/hpOneView/test/unit/test_profile.py
+++ b/hpOneView/test/unit/test_profile.py
@@ -146,7 +146,7 @@ class ProfilesTest(unittest.TestCase):
         mock_open.return_value = mock_file
         bios = self.profile.make_bios_dict(filename)
         self.assertIsNotNone(bios)
-        self.assertEquals({'manageBios': True, 'overriddenSettings': [{'value': '2', 'id': '134'}]}, bios)
+        self.assertEqual({'manageBios': True, 'overriddenSettings': [{'value': '2', 'id': '134'}]}, bios)
 
     @mock.patch(mock_builtin('open'))
     def test_make_bios_with_defaukt_options(self, mock_open):
@@ -156,7 +156,7 @@ class ProfilesTest(unittest.TestCase):
         mock_open.return_value = mock_file
         bios = self.profile.make_bios_dict(filename)
         self.assertIsNotNone(bios)
-        self.assertEquals({'manageBios': True, 'overriddenSettings': [{'id': '134'}]}, bios)
+        self.assertEqual({'manageBios': True, 'overriddenSettings': [{'id': '134'}]}, bios)
 
     @mock.patch(mock_builtin('open'))
     def test_make_bios_invalid_json(self, mock_open):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 
 [tox]
-envlist = py27, py34, py27-flake8, py27-coverage
+envlist = py27, py34, py27-coverage, py27-flake8
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
Replaced message displayed with print and followed with sys.exit by Execeptions
